### PR TITLE
add support for client TLS certificates

### DIFF
--- a/ircrobots/__init__.py
+++ b/ircrobots/__init__.py
@@ -1,5 +1,5 @@
 from .bot    import Bot
 from .server import Server
-from .params import (ConnectionParams, SASLUserPass, SASLExternal, SASLSCRAM,
+from .params import (ConnectionParams, ClientTLSCertificate, SASLUserPass, SASLExternal, SASLSCRAM,
     STSPolicy, ResumePolicy)
 from .ircv3  import Capability

--- a/ircrobots/__init__.py
+++ b/ircrobots/__init__.py
@@ -1,5 +1,5 @@
 from .bot    import Bot
 from .server import Server
-from .params import (ConnectionParams, ClientTLSCertificate, SASLUserPass, SASLExternal, SASLSCRAM,
+from .params import (ConnectionParams, ClientTLSKeypair, SASLUserPass, SASLExternal, SASLSCRAM,
     STSPolicy, ResumePolicy)
 from .ircv3  import Capability

--- a/ircrobots/interface.py
+++ b/ircrobots/interface.py
@@ -5,7 +5,7 @@ from enum    import IntEnum
 from ircstates import Server, Emit
 from irctokens import Line, Hostmask
 
-from .params   import ConnectionParams, SASLParams, STSPolicy, ResumePolicy
+from .params   import ConnectionParams, SASLParams, STSPolicy, ResumePolicy, ClientTLSCertificate
 
 class ITCPReader(object):
     async def read(self, byte_count: int):
@@ -24,11 +24,12 @@ class ITCPWriter(object):
 
 class ITCPTransport(object):
     async def connect(self,
-            hostname:   str,
-            port:       int,
-            tls:        bool,
-            tls_verify: bool=True,
-            bindhost:   Optional[str]=None
+            hostname:    str,
+            port:        int,
+            tls:         bool,
+            tls_verify:  bool=True,
+            certificate: Optional[ClientTLSCertificate]=None,
+            bindhost:    Optional[str]=None
             ) -> Tuple[ITCPReader, ITCPWriter]:
         pass
 

--- a/ircrobots/interface.py
+++ b/ircrobots/interface.py
@@ -5,7 +5,7 @@ from enum    import IntEnum
 from ircstates import Server, Emit
 from irctokens import Line, Hostmask
 
-from .params   import ConnectionParams, SASLParams, STSPolicy, ResumePolicy, ClientTLSCertificate
+from .params   import ConnectionParams, SASLParams, STSPolicy, ResumePolicy, ClientTLSKeypair
 
 class ITCPReader(object):
     async def read(self, byte_count: int):
@@ -28,7 +28,7 @@ class ITCPTransport(object):
             port:        int,
             tls:         bool,
             tls_verify:  bool=True,
-            certificate: Optional[ClientTLSCertificate]=None,
+            certificate: Optional[ClientTLSKeypair]=None,
             bindhost:    Optional[str]=None
             ) -> Tuple[ITCPReader, ITCPWriter]:
         pass

--- a/ircrobots/params.py
+++ b/ircrobots/params.py
@@ -29,7 +29,7 @@ class ResumePolicy(object):
     token:   str
 
 @dataclass
-class ClientTLSCertificate(object):
+class ClientTLSKeypair(object):
     certfile: str
     keyfile: Optional[str] = None
     password: Optional[str] = None
@@ -48,7 +48,7 @@ class ConnectionParams(object):
     password:    Optional[str] = None
     tls_verify:  bool = True
     sasl:        Optional[SASLParams] = None
-    certificate: Optional[ClientTLSCertificate] = None
+    certificate: Optional[ClientTLSKeypair] = None
 
     sts:    Optional[STSPolicy]    = None
     resume: Optional[ResumePolicy] = None

--- a/ircrobots/params.py
+++ b/ircrobots/params.py
@@ -29,6 +29,12 @@ class ResumePolicy(object):
     token:   str
 
 @dataclass
+class ClientTLSCertificate(object):
+    certfile: str
+    keyfile: Optional[str] = None
+    password: Optional[str] = None
+
+@dataclass
 class ConnectionParams(object):
     nickname: str
     host:     str
@@ -39,9 +45,10 @@ class ConnectionParams(object):
     realname: Optional[str] = None
     bindhost: Optional[str] = None
 
-    password:   Optional[str] = None
-    tls_verify: bool = True
-    sasl:       Optional[SASLParams] = None
+    password:    Optional[str] = None
+    tls_verify:  bool = True
+    sasl:        Optional[SASLParams] = None
+    certificate: Optional[ClientTLSCertificate] = None
 
     sts:    Optional[STSPolicy]    = None
     resume: Optional[ResumePolicy] = None

--- a/ircrobots/security.py
+++ b/ircrobots/security.py
@@ -1,11 +1,11 @@
 import ssl
 
 from typing  import Optional
-from .params import ClientTLSCertificate
+from .params import ClientTLSKeypair
 
 def tls_context(
     verify: bool=True,
-    certificate: Optional[ClientTLSCertificate]=None
+    certificate: Optional[ClientTLSKeypair]=None
     ) -> ssl.SSLContext:
 
     context = ssl.SSLContext(ssl.PROTOCOL_TLS)

--- a/ircrobots/security.py
+++ b/ircrobots/security.py
@@ -1,6 +1,13 @@
 import ssl
 
-def tls_context(verify: bool=True) -> ssl.SSLContext:
+from typing  import Optional
+from .params import ClientTLSCertificate
+
+def tls_context(
+    verify: bool=True,
+    certificate: Optional[ClientTLSCertificate]=None
+    ) -> ssl.SSLContext:
+
     context = ssl.SSLContext(ssl.PROTOCOL_TLS)
     context.options |= ssl.OP_NO_SSLv2
     context.options |= ssl.OP_NO_SSLv3
@@ -9,5 +16,12 @@ def tls_context(verify: bool=True) -> ssl.SSLContext:
 
     if verify:
         context.verify_mode = ssl.CERT_REQUIRED
+
+    if certificate is not None:
+        context.load_cert_chain(
+            certificate.certfile,
+            certificate.keyfile,
+            certificate.password
+        )
 
     return context

--- a/ircrobots/server.py
+++ b/ircrobots/server.py
@@ -124,9 +124,10 @@ class Server(IServer):
         reader, writer = await transport.connect(
             params.host,
             params.port,
-            tls       =params.tls,
-            tls_verify=params.tls_verify,
-            bindhost  =params.bindhost)
+            tls        =params.tls,
+            tls_verify =params.tls_verify,
+            certificate=params.certificate,
+            bindhost   =params.bindhost)
 
         self._reader = reader
         self._writer = writer

--- a/ircrobots/transport.py
+++ b/ircrobots/transport.py
@@ -4,6 +4,7 @@ from asyncio       import StreamReader, StreamWriter
 from async_stagger import open_connection
 
 from .interface import ITCPTransport, ITCPReader, ITCPWriter
+from .params    import ClientTLSCertificate
 from .security  import tls_context
 
 class TCPReader(ITCPReader):
@@ -32,16 +33,17 @@ class TCPWriter(ITCPWriter):
 
 class TCPTransport(ITCPTransport):
     async def connect(self,
-            hostname:   str,
-            port:       int,
-            tls:        bool,
-            tls_verify: bool=True,
-            bindhost:   Optional[str]=None
+            hostname:    str,
+            port:        int,
+            tls:         bool,
+            tls_verify:  bool=True,
+            certificate: Optional[ClientTLSCertificate]=None,
+            bindhost:    Optional[str]=None
             ) -> Tuple[ITCPReader, ITCPWriter]:
 
         cur_ssl: Optional[SSLContext] = None
         if tls:
-            cur_ssl = tls_context(tls_verify)
+            cur_ssl = tls_context(tls_verify, certificate)
 
         local_addr: Optional[Tuple[str, int]] = None
         if not bindhost is None:

--- a/ircrobots/transport.py
+++ b/ircrobots/transport.py
@@ -4,7 +4,7 @@ from asyncio       import StreamReader, StreamWriter
 from async_stagger import open_connection
 
 from .interface import ITCPTransport, ITCPReader, ITCPWriter
-from .params    import ClientTLSCertificate
+from .params    import ClientTLSKeypair
 from .security  import tls_context
 
 class TCPReader(ITCPReader):
@@ -37,7 +37,7 @@ class TCPTransport(ITCPTransport):
             port:        int,
             tls:         bool,
             tls_verify:  bool=True,
-            certificate: Optional[ClientTLSCertificate]=None,
+            certificate: Optional[ClientTLSKeypair]=None,
             bindhost:    Optional[str]=None
             ) -> Tuple[ITCPReader, ITCPWriter]:
 


### PR DESCRIPTION
closes #7 

working implementation:
```python
import asyncio

from irctokens import build, Line
from ircrobots import Bot as BaseBot
from ircrobots import Server as BaseServer
from ircrobots import ConnectionParams, SASLExternal, SASLSCRAM, ClientTLSCertificate

class Server(BaseServer):
    async def line_read(self, line: Line):
        print(f"{self.name} < {line.format()}")

        if line.command == "001":
            # whois ourself so we can see our client certfp
            await self.send(build("WHOIS", [self.nickname]))
    async def line_send(self, line: Line):
        print(f"{self.name} > {line.format()}")

class Bot(BaseBot):
    def create_server(self, name: str):
        return Server(self, name)

async def main():
    bot = Bot()

    sasl_params = SASLExternal()
    certificate = ClientTLSCertificate("libera.pem")
    params      = ConnectionParams(
        "tlstest1",
        host = "irc.libera.chat",
        port = 6697,
        tls  = True,
        sasl = sasl_params,
        certificate = certificate)

    await bot.add_server("libera", params)
    await bot.run()

if __name__ == "__main__":
    asyncio.run(main())
```