### PR TITLE
Small tweak to how repr() of Formatless() displays

### DIFF
--- a/ircrobots/matching/params.py
+++ b/ircrobots/matching/params.py
@@ -73,8 +73,7 @@ class Formatless(IMatchResponseParam):
     def __init__(self, value: TYPE_MAYBELIT_VALUE):
         self._value = _assure_lit(value)
     def __repr__(self) -> str:
-        brepr = super().__repr__()
-        return f"Formatless({brepr})"
+        return f"Formatless({self._value!r})"
     def match(self, server: IServer, arg: str) -> bool:
         strip = formatting.strip(arg)
         return self._value.match(server, strip)


### PR DESCRIPTION
Small tweak to how a Formatless match is displayed in repr().
Adjusts it from `Formatless(<ircrobots.matching.params.Formatless object at 0x7facabc988b0>)])` to `Formatless('hello world')`.